### PR TITLE
Add a Dockerfile & helper scripts to build on a working environment of devkitARM r47.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.partial": "nunjucks",
+        "*.html": "html",
+        "xstring": "cpp"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,21 @@
 DSiMenu++ is an open-source DSi Menu upgrade/replacement, and frontend for nds-bootstrap for DSi, and flashcards.
 
 # Building
+
 Building this app by yourself require DEVKITARM with DEVKITPRO. You will also need [Easy GL2D](https://www.odrive.com/s/eb3e676a-be1b-4a18-bc7d-67f25c80eb42-5917ab0b). Merge the contents `LibGL2D_DS.zip:/distributable/libnds/* (lib and include)` at `devkitPro/libnds/`. Also, download [this](https://www.odrive.com/s/895059a5-673c-4b3c-b3dd-8dbf0cbd8c6f-5af9d7f4) file, and place it at `devkitPro/libnds/lib`, overwriting the existing one.
 Make sure that grit and mmutil are installed.
+
+# Building with Docker
+
+DSiMenu++ comes included with a Docker image for easy building without having to manually set up the required version of devkitARM and Easy GL2D. 
+
+## Building with Docker for Windows users.
+
+You can compile DSiMenu++ with Docker using the provided PowerShell (`.ps1`) scripts. First, install docker at http://docker.com, and [configured Shared Drives](https://blogs.msdn.microsoft.com/stevelasker/2016/06/14/configuring-docker-for-windows-volumes/) for the drive where DSiMenu++ is cloned. 
+
+Then run `compile_docker.ps1` in a PowerShell window. The script accepts `make` arguments as well, for example `.\compile_docker.ps1 clean`. Note that Docker compilation is not compatible with native Windows compilation. You should run `.\compile_docker.ps1 clean` to clean the artifacts before attempting to build with Docker.
+
+To build all artifacts, run `.\compile_docker.ps1 package`.
 
 # Credits
 

--- a/booter/compile_docker.ps1
+++ b/booter/compile_docker.ps1
@@ -15,5 +15,6 @@ if (!$?) {
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
 
 if($args.Count -eq 0 -and $?) {
-    Copy-Item "romsel_dsimenutheme.nds" "../7zfile/_nds/dsimenuplusplus/dsimenu.srldr"
+    Copy-Item "booter.nds" "../7zfile/BOOT.NDS"
+	Copy-Item "booter.nds" "../7zfile/CFW - SDNAND root/title/00030015/53524c41/content/00000000.app"
 }

--- a/booter_fc/compile_docker.ps1
+++ b/booter_fc/compile_docker.ps1
@@ -9,7 +9,11 @@ docker image inspect dsimenuplusplus >$null 2>&1
 
 if (!$?) {
     # build the image if it doesn't exist.
-    docker build -t dsimenuplusplus --label dsimenuplusplus ./docker
+    docker build -t dsimenuplusplus --label dsimenuplusplus ../docker
 }
 
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
+
+if($args.Count -eq 0 -and $?) {
+    Copy-Item "booter_fc.nds" "../7zfile/BOOT_fc.nds"
+}

--- a/compile_docker.ps1
+++ b/compile_docker.ps1
@@ -1,0 +1,15 @@
+docker -v
+if (!$?) {
+    Write-Error "Docker not installed.";
+    Write-Output "Install Docker at https://www.docker.com/";
+}
+
+#check for dsimenuplusplus image
+docker image inspect dsimenuplusplus >$null 2>&1 
+
+if (!$?) {
+    # build the image if it doesn't exist.
+    docker build -t dsimenuplusplus --label dsimenuplusplus ./docker
+}
+
+docker run -t -i -v "$pwd\:/data" dsimenuplusplus make @args

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM quarktheawesome/devkitpro-arm-ppc:r47_r29
+ADD libnds.tar /devkitpro
+RUN \
+  apt-get update && \
+  apt-get install -y python && \
+  rm -rf /var/lib/apt/lists/*
+WORKDIR /data

--- a/romsel_dsimenutheme/compile_docker.ps1
+++ b/romsel_dsimenutheme/compile_docker.ps1
@@ -1,0 +1,16 @@
+docker -v
+if (!$?) {
+    Write-Error "Docker not installed.";
+    Write-Output "Install Docker at https://www.docker.com/";
+}
+
+#check for dsimenuplusplus image
+docker image inspect dsimenuplusplus >$null 2>&1 
+
+if (!$?) {
+    # build the image if it doesn't exist.
+    docker build -t dsimenuplusplus --label dsimenuplusplus ../docker
+}
+
+docker run -t -i -v "$pwd\:/data" dsimenuplusplus make @args
+Copy-Item "romsel_dsimenutheme.nds" "../7zfile/_nds/dsimenuplusplus/dsimenu.srldr"

--- a/romsel_r4theme/compile_docker.ps1
+++ b/romsel_r4theme/compile_docker.ps1
@@ -9,7 +9,11 @@ docker image inspect dsimenuplusplus >$null 2>&1
 
 if (!$?) {
     # build the image if it doesn't exist.
-    docker build -t dsimenuplusplus --label dsimenuplusplus ./docker
+    docker build -t dsimenuplusplus --label dsimenuplusplus ../docker
 }
 
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
+
+if($args.Count -eq 0 -and $?) {
+    Copy-Item "romsel_r4theme.nds" "../7zfile/_nds/dsimenuplusplus/r4menu.srldr"
+}

--- a/rungame/compile_docker.ps1
+++ b/rungame/compile_docker.ps1
@@ -9,7 +9,11 @@ docker image inspect dsimenuplusplus >$null 2>&1
 
 if (!$?) {
     # build the image if it doesn't exist.
-    docker build -t dsimenuplusplus --label dsimenuplusplus ./docker
+    docker build -t dsimenuplusplus --label dsimenuplusplus ../docker
 }
 
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
+
+if($args.Count -eq 0 -and $?) {
+    "rungame.nds" "../7zfile/CFW - SDNAND root/title/00030015/534c524e/content/00000000.app"
+}

--- a/rungame/compile_docker.ps1
+++ b/rungame/compile_docker.ps1
@@ -15,5 +15,5 @@ if (!$?) {
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
 
 if($args.Count -eq 0 -and $?) {
-    "rungame.nds" "../7zfile/CFW - SDNAND root/title/00030015/534c524e/content/00000000.app"
+    Copy-Item "rungame.nds" "../7zfile/CFW - SDNAND root/title/00030015/534c524e/content/00000000.app"
 }

--- a/titleandsettings/compile_docker.ps1
+++ b/titleandsettings/compile_docker.ps1
@@ -9,7 +9,11 @@ docker image inspect dsimenuplusplus >$null 2>&1
 
 if (!$?) {
     # build the image if it doesn't exist.
-    docker build -t dsimenuplusplus --label dsimenuplusplus ./docker
+    docker build -t dsimenuplusplus --label dsimenuplusplus ../docker
 }
 
 docker run --rm -t -i -v "$pwd\:/data" dsimenuplusplus make @args
+
+if($args.Count -eq 0 -and $?) {
+    Copy-Item "titleandsettings.nds" "../7zfile/_nds/dsimenuplusplus/main.srldr"
+}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's new?
This is a companion pull request to issue #145. While it does not fix the issue, it provides a workaround by including a working Docker image of a build environment compatible with DSiMenu++.

#### What is fixed?

It is almost impossible to acquire an installation devkitARM r47, this is by design on part of the devkitPro contributors. The current supported revision is devkitARM r49, which is not compatible with DSiMenu++. 

This pull request introduces a way to build DSiMenu++ using Docker and a Linux image with devkitARM r47, libnds 1.7.1, and EasyGL2D preinstalled as a workaround until DSiMenu++ can be updated to support devkitARM r49.

#### Where have you tested it?

5.4.0.1 built with this image works identically to the release binaries on a hardware DSi and New 3DS, as well as NO$GBA. Build scripts were tested on Windows 10 build 17778.

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
