### PR TITLE
Force a font palette refresh on UI load.

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -412,7 +412,9 @@ void displayNowLoading(void) {
 	fadeType = true;	// Fade in from white
 	printLargeCentered(false, 88, "Now Loading...");
 	nowLoadingDisplaying = true;
-	for (int i = 0; i < 35; i++) swiWaitForVBlank();
+	for (int i = 0; i < 15; i++) swiWaitForVBlank();
+	reloadFontPalettes(true);
+	for (int i = 0; i < 15; i++) swiWaitForVBlank();
 	showProgressIcon = true;
 	controlTopBright = false;
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -82,20 +82,20 @@ void fontInit()
 				);
 }
 
-void reloadFontPalettes() {
+void reloadFontPalettes(bool forceRefresh) {
 
 	uint16 cmpFontPal[4];
 
 	glBindTexture(0, fontTextureID[0]);
 	glGetColorTableEXT(0,0,0, cmpFontPal);
 
-	if (memcmp(cmpFontPal, small_fontPal, 4) != 0) {
+	if (memcmp(cmpFontPal, small_fontPal, 4) != 0 || forceRefresh || cmpFontPal == NULL) {
 		glColorSubTableEXT(0, 0, 4, 0, 0, (u16*) small_fontPal);
 	}
 
 	glBindTexture(0, fontTextureID[1]);
 	glGetColorTableEXT(0,0,0,cmpFontPal);
-	if (memcmp(cmpFontPal, large_fontPal, 4) != 0) {
+	if (memcmp(cmpFontPal, large_fontPal, 4) != 0 || forceRefresh || cmpFontPal == NULL) {
 		glColorSubTableEXT(0, 0, 4, 0, 0, (u16*) large_fontPal);
 	}
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.h
@@ -40,4 +40,4 @@ TextEntry *getPreviousTextEntry(bool top);
 TextPane &createTextPane(int startX, int startY, int shownElements);
 FontGraphic &getFont(bool large);
 void waitForPanesToClear();
-void reloadFontPalettes();
+void reloadFontPalettes(bool forceRefresh = false);


### PR DESCRIPTION
#### What's new?
Font palettes are now unconditionally refreshed when the UI is loaded (during the "Now Loading..." screen), or if the loaded font palette is null.

#### What is fixed?
This should fix the font being corrupted on startup.
#### Where have you tested it?
Nintendo DSi with latest bootstrap, Unlaunch 1.3.

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
