### PR TITLE
DSi/3DS Theme: Quick fix to immediately load icons on startup.

### DIFF
--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -119,8 +119,8 @@ void deferLoadIcon(u8 *tilesSrc, u16 *palSrc, int num, bool twl) {
  */
 void execDeferredIconUpdates() {
 	for (auto arg : queuedIconUpdateCache) {
-		auto& [tileSrc, palSrc, num, twl] = arg;
-     	convertIconTilesToRaw(tileSrc, tilesModified, twl);
+		auto& [tilesSrc, palSrc, num, twl] = arg;
+     	convertIconTilesToRaw(tilesSrc, tilesModified, twl);
 	 	glLoadIcon(num, (u16*) palSrc, (u8*)tilesModified, twl ? TWL_TEX_HEIGHT : 32); 
 	}
 	queuedIconUpdateCache.clear();
@@ -129,7 +129,13 @@ void execDeferredIconUpdates() {
 //(u8(*tilesSrc)[(32 * 32) / 2], u16(*palSrc)[16])
 void loadIcon(u8 *tilesSrc, u16 *palSrc, int num, bool twl)
 {
-	deferLoadIcon(tilesSrc, palSrc, num, twl);
+	// Hack to prevent glitched icons on startup.
+	if (showbubble) {
+		deferLoadIcon(tilesSrc, palSrc, num, twl);
+	} else {
+ 		convertIconTilesToRaw(tilesSrc, tilesModified, twl);
+	 	glLoadIcon(num, (u16*) palSrc, (u8*)tilesModified, twl ? TWL_TEX_HEIGHT : 32); 
+	}
 }
 
 void loadUnkIcon(int num)


### PR DESCRIPTION
#### What's new?

Disabled deferred icon loading when the text bubble is not shown. This has the effect of loading icons immediately on startup.

#### What is fixed?

Fixes rare issue of double icons being loaded on startup.

(Sorry for the last-minute bugfix...)

#### Where have you tested it?

- Nintendo DSi, Unlaunch 1.3.
> **Dragios** Today at 2:49 AM
> Looks like fine now. Can't seem to reproduce the issue anymore.

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
