### PR TITLE
Speed up getSDKVersion.

### DIFF
--- a/romsel_dsimenutheme/arm9/source/module_params.cpp
+++ b/romsel_dsimenutheme/arm9/source/module_params.cpp
@@ -1,0 +1,56 @@
+#include <nds.h>
+#include <stdio.h>
+#include "module_params.h"
+
+u32 buf[2];
+char moduleParamsBuf[sizeof(module_params_t)];
+
+static const u32 moduleParamsSignature[2] = {0xDEC00621, 0x2106C0DE};
+
+u32 findModuleParamsOffset(const sNDSHeaderExt *ndsHeader, FILE *ndsFile)
+{
+	fseek(ndsFile, ndsHeader->arm9romOffset, SEEK_SET);
+
+	// Offset of the module params in bytes
+	int offset = 0;
+	bool found = false;
+	while (fread(buf, sizeof(u32), 2, ndsFile) == 2)
+	{
+		// The first word of the signature is on an even offset (relative to arm9romOffset)
+		if (buf[0] == moduleParamsSignature[0] && buf[1] == moduleParamsSignature[1])
+		{
+			found = true;
+			break;
+		}
+		// The first word of the signature is on an odd offset (relative to arm9romOffset)
+		else if (buf[1] == moduleParamsSignature[0])
+		{
+			// Read the next byte and check if the next byte is the paramSignature.
+			if (fread(buf, sizeof(u32), 1, ndsFile) == 1 && buf[0] == moduleParamsSignature[1])
+			{
+				// The offset of moduleParamsSignature is at offset + 1.
+				offset += sizeof(u32);
+				found = true;
+				break;
+			}
+		}
+		offset += sizeof(u32) * 2;
+	}
+
+	if (!found)
+		return NULL;
+
+
+	return ndsHeader->arm9romOffset + offset - 0x1C;
+}
+
+module_params_t *getModuleParams(const sNDSHeaderExt *ndsHeader, FILE *ndsFile)
+{
+
+	u32 moduleParamsOffset = findModuleParamsOffset(ndsHeader, ndsFile);
+	fseek(ndsFile, moduleParamsOffset, SEEK_SET);
+	fread(moduleParamsBuf, sizeof(module_params_t), 1, ndsFile);
+
+	//module_params_t* moduleParams = (module_params_t*)((u32)moduleParamsOffset - 0x1C);
+	return moduleParamsOffset ? (module_params_t *)(moduleParamsBuf) : NULL;
+}

--- a/romsel_dsimenutheme/arm9/source/module_params.h
+++ b/romsel_dsimenutheme/arm9/source/module_params.h
@@ -1,0 +1,17 @@
+#include <nds.h>
+#include <stdio.h>
+#include "ndsheaderbanner.h"
+
+#pragma once
+#ifndef __MODULE_PARAM__
+#define __MODULE_PARAM__
+
+/**
+ * Gets a pointer to module params of a file, valid until
+ * the next call of getModuleParams.
+ * 
+ * Try to ensure that the NDS ROM actually has moduleparams,
+ * (i.e. not homebrew), else this method will be slow.
+ */
+module_params_t* getModuleParams(const sNDSHeaderExt* ndsHeader, FILE* ndsFile);
+#endif

--- a/romsel_dsimenutheme/arm9/source/ndsheaderbanner.cpp
+++ b/romsel_dsimenutheme/arm9/source/ndsheaderbanner.cpp
@@ -5,45 +5,17 @@
 #include <gl2d.h>
 
 #include "ndsheaderbanner.h"
+#include "module_params.h"
 
 extern sNDSBannerExt ndsBanner;
+
+// Needed to test if homebrew
+char tidBuf[4];
 
 typedef enum
 {
 	GL_FLIP_BOTH	= (1 << 3)
 } GL_FLIP_MODE_XTRA;
-
-// Subroutine function signatures arm9
-u32 moduleParamsSignature[2]   = {0xDEC00621, 0x2106C0DE};
-
-//
-// Look in @data for @find and return the position of it.
-//
-u32 getOffset(u32* addr, size_t size, u32* find, size_t sizeofFind, int direction)
-{
-	u32* end = addr + size/sizeof(u32);
-
-    //u32 result = 0;
-	bool found = false;
-
-	do {
-		for(int i=0;i<(int)sizeofFind;i++) {
-			if (addr[i] != find[i]) 
-			{
-				break;
-			} else if(i==(int)sizeofFind-1) {
-				found = true;
-			}
-		}
-		if(!found) addr+=direction;
-	} while (addr != end && !found);
-
-	if (addr == end) {
-		return NULL;
-	}
-
-	return (u32)addr;
-}
 
 /**
  * Get the title ID.
@@ -57,8 +29,6 @@ int grabTID(FILE* ndsFile, char *buf) {
 	return !(read == 4);
 }
 
-char arm9binary[0x40000];
-
 /**
  * Get SDK version from an NDS file.
  * @param ndsFile NDS file.
@@ -69,18 +39,8 @@ u32 getSDKVersion(FILE* ndsFile) {
 	sNDSHeaderExt NDSHeader;
 	fseek(ndsFile, 0, SEEK_SET);
 	fread(&NDSHeader, 1, sizeof(NDSHeader), ndsFile);
-	
-	fseek(ndsFile, NDSHeader.arm9romOffset, SEEK_SET);
-	if(NDSHeader.arm9binarySize > 0x40000) NDSHeader.arm9binarySize = 0x40000;
-	fread(&arm9binary, 1, NDSHeader.arm9binarySize, ndsFile);
-
-	// Looking for moduleparams
-	uint32_t moduleparams = getOffset((u32*)arm9binary, NDSHeader.arm9binarySize, (u32*)moduleParamsSignature, 2, 1);
-	if(!moduleparams) {
-		return 0;
-	}
-
-	return ((module_params_t*)(moduleparams - 0x1C))->sdk_version;
+	if (NDSHeader.arm7destination >= 0x037F8000 || grabTID(ndsFile, tidBuf) != 0) return 0;
+	return getModuleParams(&NDSHeader, ndsFile)->sdk_version;
 }
 
 // bnriconframeseq[]

--- a/romsel_r4theme/arm9/source/module_params.cpp
+++ b/romsel_r4theme/arm9/source/module_params.cpp
@@ -1,0 +1,56 @@
+#include <nds.h>
+#include <stdio.h>
+#include "module_params.h"
+
+u32 buf[2];
+char moduleParamsBuf[sizeof(module_params_t)];
+
+static const u32 moduleParamsSignature[2] = {0xDEC00621, 0x2106C0DE};
+
+u32 findModuleParamsOffset(const sNDSHeaderExt *ndsHeader, FILE *ndsFile)
+{
+	fseek(ndsFile, ndsHeader->arm9romOffset, SEEK_SET);
+
+	// Offset of the module params in bytes
+	int offset = 0;
+	bool found = false;
+	while (fread(buf, sizeof(u32), 2, ndsFile) == 2)
+	{
+		// The first word of the signature is on an even offset (relative to arm9romOffset)
+		if (buf[0] == moduleParamsSignature[0] && buf[1] == moduleParamsSignature[1])
+		{
+			found = true;
+			break;
+		}
+		// The first word of the signature is on an odd offset (relative to arm9romOffset)
+		else if (buf[1] == moduleParamsSignature[0])
+		{
+			// Read the next byte and check if the next byte is the paramSignature.
+			if (fread(buf, sizeof(u32), 1, ndsFile) == 1 && buf[0] == moduleParamsSignature[1])
+			{
+				// The offset of moduleParamsSignature is at offset + 1.
+				offset += sizeof(u32);
+				found = true;
+				break;
+			}
+		}
+		offset += sizeof(u32) * 2;
+	}
+
+	if (!found)
+		return NULL;
+
+
+	return ndsHeader->arm9romOffset + offset - 0x1C;
+}
+
+module_params_t *getModuleParams(const sNDSHeaderExt *ndsHeader, FILE *ndsFile)
+{
+
+	u32 moduleParamsOffset = findModuleParamsOffset(ndsHeader, ndsFile);
+	fseek(ndsFile, moduleParamsOffset, SEEK_SET);
+	fread(moduleParamsBuf, sizeof(module_params_t), 1, ndsFile);
+
+	//module_params_t* moduleParams = (module_params_t*)((u32)moduleParamsOffset - 0x1C);
+	return moduleParamsOffset ? (module_params_t *)(moduleParamsBuf) : NULL;
+}

--- a/romsel_r4theme/arm9/source/module_params.h
+++ b/romsel_r4theme/arm9/source/module_params.h
@@ -1,0 +1,16 @@
+#include <nds.h>
+#include <stdio.h>
+#include "ndsheaderbanner.h"
+
+#pragma once
+#ifndef __MODULE_PARAM__
+#define __MODULE_PARAM__
+/**
+ * Gets a pointer to module params of a file, valid until
+ * the next call of getModuleParams.
+ * 
+ * Try to ensure that the NDS ROM actually has moduleparams,
+ * (i.e. not homebrew), else this method will be slow.
+ */
+module_params_t* getModuleParams(const sNDSHeaderExt* ndsHeader, FILE* ndsFile);
+#endif


### PR DESCRIPTION
#### What's new?

Finding the module parameters offset is now done without needing to copy a huge chunk of the ARM9 binary. This is generally really fast in the best case (actually contains module params), and nearly slower than the old implementation in the worst case (i.e. is Homebrew), so some preliminary checking is done before attempting to get the SDK version.

#### Where have you tested it?

Nintendo DSi, Unlaunch 1.3

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
