### PR TITLE
Fix some small akmenu bugs.

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -156,7 +156,15 @@ bool MainList::enterDir(const std::string &dirName)
         if (!sys().flashcardUsed())
         {
             // TODO: Show "SD Card" if consoleModel is < 3, else show "microSD Card"
-            addDirEntry(0, LANG("mainlist", "SD Card"), "", SD_ROOT, "usd", microsd_banner_bin);
+
+            if (ms().showDirectories)
+            {
+                addDirEntry(0, LANG("mainlist", "SD Card"), "", SD_ROOT, "usd", microsd_banner_bin);
+            }
+            else
+            {
+                addDirEntry(0, LANG("mainlist", "SD Card"), "", ms().romfolder, "usd", microsd_banner_bin);
+            }
         }
         else
         {
@@ -258,8 +266,7 @@ bool MainList::enterDir(const std::string &dirName)
                     extName = "";
 
                 dbg_printf("%s: %s %s\n", (st.st_mode & S_IFDIR ? " DIR" : "FILE"), lfnBuf, extName.c_str());
-                bool showThis = (st.st_mode & S_IFDIR) ? 
-                    (strcmp(lfn.c_str(), ".") && strcmp(lfn.c_str(), "..")  && strcmp(lfn.c_str(), "_nds") && ms().showDirectories) : extnameFilter(extNames, extName);
+                bool showThis = (st.st_mode & S_IFDIR) ? (strcmp(lfn.c_str(), ".") && strcmp(lfn.c_str(), "..") && strcmp(lfn.c_str(), "_nds") && ms().showDirectories) : extnameFilter(extNames, extName);
                 showThis = showThis && (_showAllFiles || !(attr & ATTRIB_HID));
 
                 if (showThis)
@@ -372,10 +379,17 @@ void MainList::backParentDir()
         return;
 
     dbg_printf("CURDIR:\"%s\"\n", _currentDir.c_str());
-    if ("" == _currentDir || SD_ROOT == _currentDir)
+    if ("" == _currentDir || SD_ROOT == _currentDir || !ms().showDirectories)
     {
         dbg_printf("Entering HOME\n");
         enterDir(SPATH_ROOT);
+        return;
+    }
+
+    if (!ms().showDirectories)
+    {
+        // Allow going back into the root, but don't allow going
+        // back in other directories.
         return;
     }
 

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -166,7 +166,10 @@ void MainWnd::init()
     _folderText->setRelativePosition(Point(x, y));
     _folderText->setTextColor(ini.GetInt("folder text", "color", 0));
     addChildWindow(_folderText);
-
+    
+    if (!ms().showDirectories) {
+        _folderText->hide();
+    }
     // init startmenu
     _startMenu = new StartMenu(160, 40, 61, 108, this, "start menu");
     //_startMenu->setRelativePosition( Point(160, 40) );

--- a/titleandsettings/arm9/source/soundeffect.h
+++ b/titleandsettings/arm9/source/soundeffect.h
@@ -11,7 +11,10 @@
 class SoundEffect
 {
   public:
-    SoundEffect(): music(false) {}
+    SoundEffect(): music(false) {
+        music = false;
+        counter = 0;
+    }
     ~SoundEffect() {}
 
     void init()
@@ -81,8 +84,8 @@ class SoundEffect
     {
         if (!music)
         {
-            mmEffectEx(&mus_settings); // Play settings music
             music = true;
+            mmEffectEx(&mus_settings); // Play settings music
         }
     }
 


### PR DESCRIPTION
#### What is fixed?

* Disallowed going up the folder hierarchy if `showDirectories` is false
* Initialized sound effect state variables in titleandsettings to prevent odd sound bugs.

#### Where have you tested it?
Nintendo DS with Unlaunch 1.3

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
