### PR TITLE
Remove outdated description for DESCRIPTION_ANIMATEDSIICONS_1

### DIFF
--- a/titleandsettings/nitrofiles/languages/english.ini
+++ b/titleandsettings/nitrofiles/languages/english.ini
@@ -37,7 +37,7 @@ DESCRIPTION_DIRECTORIES_1 = If you are in a folder where most|of your games are,
 
 DESCRIPTION_BOXART_1 = Displayed in the top screen|of the DSi/3DS theme.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus. Turning this off|will fix some icons appearing white.
+DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = START button will be used to launch|a game instead of A, where A|will bring up per-game settings.
 

--- a/titleandsettings/nitrofiles/languages/french.ini
+++ b/titleandsettings/nitrofiles/languages/french.ini
@@ -1,4 +1,4 @@
-[LANGUAGE]
+﻿[LANGUAGE]
 SAVING_SETTINGS = Enregistrement des parametres ...
 SETTINGS_SAVED = Parametres sauvegardes!
 
@@ -38,7 +38,7 @@ DESCRIPTION_DIRECTORIES_1 = If you are in a folder where most|of your games are,
 
 DESCRIPTION_BOXART_1 = Displayed in the top screen|of the DSi/3DS theme.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus. Turning this off|will fix some icons appearing white.
+DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = START button will be used to launch|a game instead of A, where A|will bring up per-game settings.
 

--- a/titleandsettings/nitrofiles/languages/german.ini
+++ b/titleandsettings/nitrofiles/languages/german.ini
@@ -1,4 +1,4 @@
-[LANGUAGE]
+﻿[LANGUAGE]
 SAVING_SETTINGS = Speichere Einstellungen...
 SETTINGS_SAVED = Gespeichert!
 
@@ -38,7 +38,7 @@ DESCRIPTION_DIRECTORIES_1 = Wenn du dich in dem Ordner befindest,|in welchem sic
 
 DESCRIPTION_BOXART_1 = Wird auf dem oberen Bildschirm|beim DSi/3DS-Theme angezeigt.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Animierte DSi-Spezielle Icons wie in|den DSi/3DS Menüs. Deaktivieren kann|bei manchen weiß angezeigten Icons helfen.
+DESCRIPTION_ANIMATEDSIICONS_1 = Animierte DSi-Spezielle Icons wie in|den DSi/3DS Menüs.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = Spiel wird mit START anstatt|A ausgeführt und A öffnet die|per-Spiel Einstellungen.
 

--- a/titleandsettings/nitrofiles/languages/italian.ini
+++ b/titleandsettings/nitrofiles/languages/italian.ini
@@ -1,4 +1,4 @@
-[LANGUAGE]
+﻿[LANGUAGE]
 SAVING_SETTINGS = Salvataggio delle impostazioni...
 SETTINGS_SAVED = Impostazioni salvate!
 
@@ -39,7 +39,7 @@ DESCRIPTION_DIRECTORIES_1 = Se sei in una cartella dove sono presenti|molti dei 
 
 DESCRIPTION_BOXART_1 = Mostrato nello schermo superiore|del tema DSi/3DS.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Anima le icone DSi come nei Menu DSi|e 3DS. Disattivandola sistemerà|alcune icone che appaiono bianche.
+DESCRIPTION_ANIMATEDSIICONS_1 = Anima le icone DSi come nei Menu DSi|e 3DS.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = Il pulsante START verrà utilizzato per|avviare i giochi, invece A aprirà|le impostazioni per gioco.
 

--- a/titleandsettings/nitrofiles/languages/japanese.ini
+++ b/titleandsettings/nitrofiles/languages/japanese.ini
@@ -37,7 +37,7 @@ DESCRIPTION_DIRECTORIES_1 = If you are in a folder where most|of your games are,
 
 DESCRIPTION_BOXART_1 = Displayed in the top screen|of the DSi/3DS theme.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus. Turning this off|will fix some icons appearing white.
+DESCRIPTION_ANIMATEDSIICONS_1 = Animates DSi-enhanced icons like in|the DSi/3DS menus.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = START button will be used to launch|a game instead of A, where A|will bring up per-game settings.
 

--- a/titleandsettings/nitrofiles/languages/spanish.ini
+++ b/titleandsettings/nitrofiles/languages/spanish.ini
@@ -1,4 +1,4 @@
-[LANGUAGE]
+﻿[LANGUAGE]
 SAVING_SETTINGS = Guardar los ajustes...
 SETTINGS_SAVED = ¡Ajustes guardados!
 
@@ -38,7 +38,7 @@ DESCRIPTION_DIRECTORIES_1 = Si estás en una carpeta donde la mayoría|de tus ju
 
 DESCRIPTION_BOXART_1 = Mostrado en la pantalla superior|Del tema de DSi/3DS.
 
-DESCRIPTION_ANIMATEDSIICONS_1 = Anima los íconos DSi-enhanced como en|los menus de DSi/3DS. Desabilitar esto|corregirá algunos iconos que aparecen en blanco.
+DESCRIPTION_ANIMATEDSIICONS_1 = Anima los íconos DSi-enhanced como en|los menus de DSi/3DS.
 
 DESCRIPTION_STARTBUTTONLAUNCH_1 = START button will be used to launch|a game instead of A, where A|will bring up per-game settings.
 


### PR DESCRIPTION
#### What is fixed?

Remove outdated description for certain icons appearing white when turning on animated DSi-enhanced icon as this is already fixed as of v.5.2.0

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
